### PR TITLE
Fix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gpt4all-ts 🌐🚀📚
 
+⚠️ Does not yet support GPT4All-J
+
 gpt4all-ts is a TypeScript library that provides an interface to interact with GPT4All, which was originally implemented in Python using the [nomic SDK](https://github.com/nomic-ai/nomic/blob/main/nomic/gpt4all/gpt4all.py). This library aims to extend and bring the amazing capabilities of GPT4All to the TypeScript ecosystem.
 
 gpt4all-ts is inspired by and built upon the GPT4All project, which offers code, data, and demos based on the LLaMa large language model with around 800k GPT-3.5-Turbo Generations 😲. You can find the GPT4All Readme [here](https://github.com/nomic-ai/gpt4all#readme) to learn more about the project.

--- a/src/gpt4all.ts
+++ b/src/gpt4all.ts
@@ -87,16 +87,16 @@ Intel Mac/OSX: cd chat;./gpt4all-lora-quantized-OSX-intel
             // check for M1 Mac
             const {stdout} = await promisify(exec)('uname -m');
             if (stdout.trim() === 'arm64') {
-                upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/chat/gpt4all-lora-quantized-OSX-m1?raw=true';
+                upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-training/chat/gpt4all-lora-quantized-OSX-m1?raw=true';
             } else {
-                upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/chat/gpt4all-lora-quantized-OSX-intel?raw=true';
+                upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-training/chat/gpt4all-lora-quantized-OSX-intel?raw=true';
             }
         } 
         else if (platform === 'linux') {
-            upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/chat/gpt4all-lora-quantized-linux-x86?raw=true';
+            upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-training/chat/gpt4all-lora-quantized-linux-x86?raw=true';
         } 
         else if(platform === 'win32') {
-            upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/chat/gpt4all-lora-quantized-win64.exe?raw=true';
+            upstream = 'https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-training/chat/gpt4all-lora-quantized-win64.exe?raw=true';
         } 
         else {
             throw new Error(`Your platform is not supported: ${platform}. Current binaries supported are for OSX (ARM and Intel), Linux and Windows.`);


### PR DESCRIPTION
About a week ago, a repo restructure resulted in these files changing location (see [here](https://github.com/nomic-ai/gpt4all/commits/f8fdcccc5d253229808c0ceb9c5faae1ba42f68c/gpt4all-training/chat/gpt4all-lora-quantized-OSX-intel)). This commit fixes the file location to quickly resolve the problem. Fixes #26 and unblocks https://github.com/hwchase17/langchainjs/pull/1204.

_Imo longer term support is needed from @nomic-ai on this project given it doesn't support GPT4All-J yet._